### PR TITLE
feat: add block creation number to parcel entity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -16,6 +16,7 @@ type Bidder @entity {
 
 type GeoWebParcel @entity {
   id: ID!
+  createdAtBlock: BigInt!
   licenseOwner: Bytes
   currentBid: Bid
   pendingBid: Bid

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -43,6 +43,8 @@ export function handleParcelClaimed(event: ParcelClaimed): void {
     parcelEntity = new GeoWebParcel(event.params._licenseId.toHex());
   }
 
+  parcelEntity.createdAtBlock = event.block.number;
+
   let contract = RegistryDiamond.bind(event.address);
   let parcel = contract.getLandParcel(event.params._licenseId);
 
@@ -139,6 +141,8 @@ export function handleParcelClaimedV2(event: ParcelClaimedV2): void {
   if (parcelEntity == null) {
     parcelEntity = new GeoWebParcel(event.params._licenseId.toHex());
   }
+
+  parcelEntity.createdAtBlock = event.block.number;
 
   let contract = RegistryDiamond.bind(event.address);
   let parcel = contract.getLandParcelV2(event.params._licenseId);


### PR DESCRIPTION
Add `createdAtBlock` field to the `GeoWebParcel` entity.